### PR TITLE
Use /gems/ in default exclusion pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.gem
+
+/.yardoc
+/doc

--- a/lib/sql_tagger.rb
+++ b/lib/sql_tagger.rb
@@ -17,7 +17,7 @@ class SqlTagger
   attr_reader :exclusion_cache
 
   def initialize
-    @exclusion_pattern = /^#{RbConfig::CONFIG['prefix']}|\/bundle\/|\/vendor\//
+    @exclusion_pattern = %r{\A#{RbConfig::CONFIG['prefix']}|/gems/}
     @exclusion_cache = Set.new
   end
 


### PR DESCRIPTION
This works for rvm gemsets (although I dislike rvm).
