### PR TITLE
Add method_defined? check in SqlTagger::ModuleMethods

### DIFF
--- a/lib/sql_tagger.rb
+++ b/lib/sql_tagger.rb
@@ -94,8 +94,10 @@ class SqlTagger
       base.send(:include, SqlTagger::Initializer)
       self.instance_methods.map(&:to_s).grep(/_with_sql_tagger$/).each do |with_method|
         target = with_method.sub(/_with_sql_tagger$/, '')
-        base.send(:alias_method, "#{target}_without_sql_tagger", target)
-        base.send(:alias_method, target, with_method)
+        if base.method_defined?(target)
+          base.send(:alias_method, "#{target}_without_sql_tagger", target)
+          base.send(:alias_method, target, with_method)
+        end
       end
     end
   end

--- a/spec/sql_tagger_spec.rb
+++ b/spec/sql_tagger_spec.rb
@@ -70,4 +70,30 @@ RSpec.describe SqlTagger do
       expect(SqlTagger.default.exclusion_pattern).to be_a(Regexp)
     end
   end
+
+  describe SqlTagger::ModuleMethods do
+    describe '#included' do
+      let(:adapter_class) do
+        Module.new do
+          extend SqlTagger::ModuleMethods
+
+          def foo_with_sql_tagger; end
+
+          def bar_with_sql_tagger; end
+        end
+      end
+
+      let(:receiver_class) do
+        Class.new do
+          def foo; end
+        end
+      end
+
+      it 'does not fail for methods that do not exist on the receiver' do
+        expect {
+          receiver_class.send(:include, adapter_class)
+        }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
This will prevent errors in the event that a class from a SQL gem
doesn't have the expected methods (from being too old or too new).
